### PR TITLE
fix: correct wording in the security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Include the following information (as much as you can provide):
 
 ## Disclosure Policy
 
-- Security vulnerabilities will be disclosed after a fix has been released
+- Security vulnerabilities will be disclosed after fix has been released
 - We will coordinate with you to determine an appropriate disclosure date
 - We aim to patch confirmed vulnerabilities within 30 days
 - Public disclosure will include credit to the reporter unless anonymity is requested


### PR DESCRIPTION
This pull request makes a minor grammatical correction in the `SECURITY.md` file to improve clarity.

* [`SECURITY.md`](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L36-R36): Updated the sentence in the disclosure policy section to fix a grammatical issue by removing the article "a" before "fix has been released."