### PR TITLE
refactor: clean up middleware by removing obsolete sign-in redirectio…

### DIFF
--- a/nextjs-temp/src/config/auth.ts
+++ b/nextjs-temp/src/config/auth.ts
@@ -7,7 +7,7 @@ import { PrismaClient } from "@prisma/client";
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 export const prisma = globalForPrisma.prisma || new PrismaClient({
-  log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
 });
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
@@ -59,34 +59,30 @@ export const authOptions: AuthOptions = {
         async redirect({ url, baseUrl }) {
             // Handle production domain explicitly
             const productionDomain = "https://sonneai.com";
-            
+
             // Check if on production domain
             if (process.env.NODE_ENV === 'production' && url.startsWith(productionDomain)) {
                 return url;
             }
-            
+
             // Allow OAuth callback URLs through
             if (url.includes('/api/auth/callback/')) {
                 return url;
             }
-            
+
             // Handle relative URLs
             if (url.startsWith('/')) {
                 return `${baseUrl}${url}`;
             }
-            
+
             // Allow internal URLs
             if (url.startsWith(baseUrl)) {
                 return url;
             }
-            
+
             // Default fallback to base URL
             return baseUrl;
         },
-    },
-    pages: {
-        signIn: '/auth/signin',
-        error: '/auth/error',
     },
     useSecureCookies: process.env.NODE_ENV === "production",
 };

--- a/nextjs-temp/src/middleware.ts
+++ b/nextjs-temp/src/middleware.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
 
 export const config = {
     matcher: [
@@ -16,9 +15,6 @@ export const config = {
 };
 
 export default async function middleware(req: NextRequest) {
-    const token = await getToken({ req });
-    const isAuthenticated = !!token;
-
     // Get the pathname of the request
     const pathname = req.nextUrl.pathname;
 

--- a/nextjs-temp/src/middleware.ts
+++ b/nextjs-temp/src/middleware.ts
@@ -22,16 +22,6 @@ export default async function middleware(req: NextRequest) {
     // Get the pathname of the request
     const pathname = req.nextUrl.pathname;
 
-    // If someone tries to access the old signin page (which no longer exists),
-    // either redirect to home (if authenticated) or to the built-in NextAuth sign-in
-    if (pathname.startsWith('/auth/signin')) {
-        if (isAuthenticated) {
-            return NextResponse.redirect(new URL('/', req.url));
-        } else {
-            return NextResponse.redirect(new URL('/api/auth/signin', req.url));
-        }
-    }
-
     // Use the original request headers without modifying them
     // This should prevent duplicate CSP headers from being added
     const response = NextResponse.next();


### PR DESCRIPTION
This pull request removes custom sign-in and error page configurations and cleans up middleware logic related to the deprecated sign-in page. These changes simplify the authentication setup by relying on default NextAuth behavior.

### Authentication configuration updates:
* Removed the `pages` property from the `authOptions` configuration in `nextjs-temp/src/config/auth.ts`, which previously defined custom paths for the sign-in and error pages.

### Middleware cleanup:
* Removed logic in `nextjs-temp/src/middleware.ts` that handled redirects for the deprecated `/auth/signin` route, as it is no longer needed.